### PR TITLE
Fix: updated Copyright owner

### DIFF
--- a/projects/carousel/LICENSE
+++ b/projects/carousel/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2022 Liz
+Copyright (c) 2022 The New York Times
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Updated Copyright text from:

"Copyright (c) 2022 Liz" to: "Copyright (c) 2022 The New York Times"